### PR TITLE
Hda tab code review

### DIFF
--- a/demo/addons/hego/ui/hda_tab.gd
+++ b/demo/addons/hego/ui/hda_tab.gd
@@ -224,6 +224,15 @@ func create_preset_file(preset_name: String) -> void:
 		if preset:
 			var asset_name = hego_tool_node.hego_get_asset_name()
 			var res_path = "res://hego/presets/" + asset_name + ".tres"
+			
+			# Ensure directory exists
+			var dir = DirAccess.open("res://")
+			var asset_dir = asset_name.get_base_dir()
+			if asset_dir != "":
+				var preset_dir = "hego/presets/" + asset_dir
+				if not dir.dir_exists(preset_dir):
+					dir.make_dir_recursive(preset_dir)
+
 			var presets_res: HEGoHDAPreset
 			# Check if the resource exists
 			if ResourceLoader.exists(res_path):


### PR DESCRIPTION
- Improved some code on the loading and saving of presets. 
- Buttons now start of disabled until you click on a HEGoNode3D
- Create directory if it doesn't exist already when saving a preset
- Replace repetitive if/elif chains in add_parm_ui() with cleaner mapping-based parameter instantiation
- Add HEGoParmType enum for type-safe parameter type constants
- Introduce PARM_UI_SCENES mapping to associate parameter types with their UI scene files
- Extract specialized handling into separate functions:
  - _create_parm_ui() - Uses mapping with size-based selection for INT/FLOAT variants
  - _setup_common_parm() - Centralizes common parameter setup logic
  - _handle_folder_parm() - Handles folder parameters with child recursion
  - _handle_multiparm_parm() - Manages complex multiparm instance creation
- Reduce code duplication and improve maintainability by eliminating 60+ lines of repetitive parameter type checking
- Preserve all existing functionality while making the codebase more extensible for future parameter types